### PR TITLE
설명서: 앱 다운로드 안내 추가 및 간편 안내 준비 항목 줄바꿈

### DIFF
--- a/docs/signalwiz_detailed_manual.html
+++ b/docs/signalwiz_detailed_manual.html
@@ -252,7 +252,8 @@
             <ol class="step-list">
                 <li><span class="step-title">기기 충전</span>측정 전에 USB Type-C 케이블로 SignalWiz 기기 본체를 충분히 충전합니다. 완충 시 약
                     13시간 연속 사용할 수 있으며, 장시간 측정 시에는 배터리 잔량을 미리 확인합니다.</li>
-                <li><span class="step-title">앱 설치</span>SignalWiz 모바일 앱을 스마트폰에 설치합니다. (Android 10 이상 기기 권장)</li>
+                <li><span class="step-title">앱 설치</span>구글 Play 스토어에서 <strong>‘Signalwiz mobile’</strong> 앱을 검색하여 스마트폰에
+                    설치합니다. (Android 10 이상 기기 권장)</li>
                 <li><span class="step-title">블루투스 권한 허용</span>앱을 처음 실행하면 블루투스 검색·연결 권한 요청이 표시됩니다. 모두 허용합니다.
                     Android 11 이하에서는 기기 검색을 위해 위치 권한도 필요합니다.</li>
                 <li><span class="step-title">알림 권한 허용</span>녹화는 백그라운드 서비스로 동작하므로, 측정 중 상태 알림 표시를 위해 알림 권한을

--- a/docs/signalwiz_quick.html
+++ b/docs/signalwiz_quick.html
@@ -33,8 +33,9 @@
         <section class="manual-section" id="prep">
             <div class="info-box">
                 <strong>시작 전 준비</strong>
-                <p>① SignalWiz 기기 본체를 USB Type-C로 충전합니다. ② SignalWiz 모바일 앱을 설치하고 블루투스·알림 권한을
-                    허용합니다. ③ 골드컵 전극·전도성 페이스트·하이파픽스 테이프를 준비합니다.</p>
+                <p>① SignalWiz 기기 본체를 USB Type-C로 충전합니다.<br>
+                    ② 구글 Play 스토어에서 <strong>‘Signalwiz mobile’</strong> 앱을 검색·설치하고 블루투스·알림 권한을 허용합니다.<br>
+                    ③ 골드컵 전극·전도성 페이스트·하이파픽스 테이프를 준비합니다.</p>
             </div>
         </section>
 


### PR DESCRIPTION
## 개요
SignalWiz 간편 안내·상세 제품 사용설명서에 앱 다운로드 경로를 명시하고, 간편 안내의 준비 항목 가독성을 개선합니다.

## 변경 내용
- **간편 안내 '시작 전 준비'**: ①②③ 항목을 각각 줄바꿈하여 3줄로 표시
- **앱 다운로드 안내 추가(양쪽 문서)**: 구글 Play 스토어에서 **'Signalwiz mobile'** 앱을 검색·설치하도록 안내
  - 간편 안내: 준비 항목 ②에 포함
  - 상세 설명서: 4장 '앱 설치' 단계에 반영
  - 스토어 표기는 실제 앱 등록명 `Signalwiz mobile`(소문자)을 그대로 사용

## 변경 파일
- `docs/signalwiz_quick.html`
- `docs/signalwiz_detailed_manual.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)